### PR TITLE
Avoid warnings with ruby -w

### DIFF
--- a/lib/memcache/server.rb
+++ b/lib/memcache/server.rb
@@ -30,7 +30,7 @@ class Memcache
     end
 
     def alive?
-      @retry_at.nil? or @retry_at < Time.now
+      not instance_variable_defined?(:@retry_at) or @retry_at.nil? or @retry_at < Time.now
     end
 
     def strict_reads?
@@ -231,7 +231,7 @@ class Memcache
     end
 
     def socket
-      if @socket.nil? or @socket.closed?
+      if not instance_variable_defined?(:@socket) or @socket.nil? or @socket.closed?
         # Attempt to connect.
         @socket = timeout(CONNECT_TIMEOUT) do
           TCPSocket.new(host, port)


### PR DESCRIPTION
Hi there,

since there are some instance variables not initialized in constructor ruby -w warns about the usage of undefined variables. To avoid this you have additionally to check for instance_variable_defined?. This is what my patch does.

Greetings,
 CK
