### PR TITLE
OS X extension fix

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -10,6 +10,19 @@ BUNDLE_PATH = BUNDLE.sub(".tar.gz", "")
 
 $CXXFLAGS = " -std=gnu++98 -fPIC"
 
+def copy_gem(gem_dir)
+  Dir.chdir("#{HERE}/#{gem_dir}") do
+    # determine the extension
+    unless ['so', 'dylib', 'dll'].detect { |ext|
+      if File.exist?("#{HERE}/#{gem_dir}/libmemcached.#{ext}")
+        system("cp -f libmemcached.#{ext} #{HERE}/lib/libmemcached_gem.#{ext}")
+      end
+    }
+      raise 'Unknown libmemcached extension'
+    end
+  end
+end
+
 if !ENV["EXTERNAL_LIB"]
   $includes    = " -I#{HERE}/include"
   $libraries   = " -L#{HERE}/lib"
@@ -51,19 +64,6 @@ if !ENV["EXTERNAL_LIB"]
   end
 
   $LIBS << " -lmemcached_gem"
-end
-
-def copy_gem(gem_dir)
-  Dir.chdir("#{HERE}/#{gem_dir}") do
-    # determine the extension
-    unless ['so', 'dylib', 'dll'].detect { |ext|
-      if File.exist?("#{HERE}/#{gem_dir}/libmemcached.#{ext}")
-        system("cp -f libmemcached.#{ext} #{HERE}/lib/libmemcached_gem.#{ext}")
-      end
-    }
-      raise 'Unknown libmemcached extension'
-    end
-  end
 end
 
 # ------------------------------------------------------


### PR DESCRIPTION
I added dynamic extension lookup for the libmemcached shared libraries.

I was unable to test if it was correct to also do that for the amd64 architecture, but I assume it's fine.
