### PR TITLE
Append the std gnu line to existing CXXFLAGS

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -41,7 +41,7 @@ if !ENV["EXTERNAL_LIB"]
         puts(cmd = "./configure --prefix=#{HERE} --without-memcached --disable-dependency-tracking #{ARGV.join(' ')} 2>&1")
         raise "'#{cmd}' failed" unless system(cmd)
 
-        puts(cmd = "make CXXFLAGS='#{$CXXFLAGS}' 2>&1")
+        puts(cmd = "make CXXFLAGS=\"$CXXFLAGS #{$CXXFLAGS}\" 2>&1")
         raise "'#{cmd}' failed" unless system(cmd)
 
         puts(cmd = "make install 2>&1")


### PR DESCRIPTION
We need to append to CXXFLAGS here instead of overwrite it. This is why originally included lib dirs are not being found when building native extensions.
