### PR TITLE
Fixed typographical error, changed architechture to architecture in README.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -103,7 +103,7 @@ changes:
 
 === Implementation
 
-The underlying architechture of _memcache_ is more modular than memcache-client.
+The underlying architecture of _memcache_ is more modular than memcache-client.
 A given +Memcache+ instance has a group of servers, just like before, but much more of the
 functionality is encapsulated inside the <tt>Memcache::Server</tt> object. Really, a +Server+
 object is a thin wrapper around an remote memcached server that takes care of the socket


### PR DESCRIPTION
@ninjudd, I've corrected a typographical error in the documentation of the [memcache](https://github.com/ninjudd/memcache) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
